### PR TITLE
Prevent ANYONECANPAY-signed inputs replay

### DIFF
--- a/transactions.md
+++ b/transactions.md
@@ -115,6 +115,11 @@ The CPFP output value is adjusted depending on the actual transaction size.
 The transaction which spends the [`unvault_tx`](unvault_tx) `output[0]` using the N-of-N path and 
 pays back to a deposit output (it is therefore another vault deposit transaction).
 
+In addition to the deposit output, the Cancel transaction features a data-carrying output committing
+to the Unvault transaction it's used for in order for the `ANYONECANPAY | ALL` signature to not be replayed
+on another Cancel transaction paying to the same deposit.
+
+
 - version: 2
 - locktime: 0
 
@@ -130,10 +135,13 @@ pays back to a deposit output (it is therefore another vault deposit transaction
 
 #### OUT
 
-- count: 1
+- count: 2
 - outputs[0]:
     - value: `<unvault_tx outputs[0] value - tx_fee>`
     - scriptPubkey: `deposit_descriptor`
+- outputs[1]:
+    - value: `0`
+    - scriptPubkey: '`RETURN <unvault_txid>`'
 
 
 ## emergency_txs
@@ -144,6 +152,10 @@ by the participants and kept obfuscated by the properties of P2WSH, as the emerg
 transactions are never meant to be used.
 
 The Emergency `scriptPubKey` is not known to the managers.
+
+In addition to the deposit output, the Emergency transaction features a data-carrying output committing
+to the Deposit transaction it's used for in order for the `ANYONECANPAY | ALL` signature to not be replayed
+on another Emergency transaction paying to the same deposit.
 
 
 ### deposit_emergency_tx
@@ -165,15 +177,22 @@ The transaction which spends the [`deposit_tx`](deposit_tx) output to the EDV by
 
 #### OUT
 
-- count: 1
+- count: 2
 - outputs[0]:
     - value: `<deposit_tx output value - fees>`
     - scriptPubkey: `0x00 SHA256(<EDV_script>)`
+- outputs[1]:
+    - value: `0`
+    - scriptPubkey: `RETURN <sha256(deposit_tx txid | deposit_tx vout)>`
 
 
 ### unvault_emergency_tx
 
 This transaction spends the [`unvault_tx`](unvault_tx) `output[0]` to the EDV by the `N`-of-`N` path.
+
+In addition to the deposit output, the Unvault Emergency transaction features a data-carrying output committing
+to the Unvault transaction it's used for in order for the `ANYONECANPAY | ALL` signature to not be replayed
+on another Unvault Emergency transaction paying to the same deposit.
 
 - version: 2
 - locktime: 0
@@ -190,10 +209,13 @@ This transaction spends the [`unvault_tx`](unvault_tx) `output[0]` to the EDV by
 
 #### OUT
 
-- count: 1
+- count: 2
 - outputs[0]:
     - value: `<unvault_tx outputs[0] value - fees>`
     - scriptPubkey: `0x00 SHA256(<EDV_script>)`
+- outputs[1]:
+    - value: `0`
+    - scriptPubkey: '`RETURN <unvault_txid>`'
 
 
 ## bypass_tx


### PR DESCRIPTION
In order for watchtowers to be able to fee-bump Cancel and Emergencies transactions and to get around transactions pining, stakeholders exchange `ANYONECANPAY | ALL` signatures.

It was [known](https://github.com/revault/practical-revault/blob/master/revault.pdf) that the malleability introduced could cause some issues, however they were minors and mostly considered in the realm of fee bumping (eg stripping the fee bumping input). Now, some design decisions make it actually practical to DOS the operation by merging Cancel or Emergencies transactions together (effectively burning an entire input to fees) under certain conditions.

Consider the Cancel transaction.
Two deposit transactions paying to the same address for the same amount will create a transaction chain ultimately paying to the Cancel output (same address and amount, as we reuse keys across the transaction chain and have static fees).
The `ACP | ALL` will not (as would a `ACP | SINGLE`) commit to the input index used, it can therefore be freely placed as second, third, or whatever input in a transaction given that this transaction contains a single output to the Cancel utxo.
Thus, the signature would be valid as a second input of a second transaction. It would effectively result in burning an entire vault.

Therefore we need a way to commit to a specifc Unvault txo (or Deposit for an Emergency) per *transaction* or to the index in the transaction. There are many ways to do so:
- We could require another set of signatures, this time `ACP | SINGLE` which would prevent it to be used as `nth` input in another transaction.
- We could abuse the `nSequence` and `nLockTime` unused bits (like Lightning does) to commit to part of the bits of the spent outpoint. However we could not stuff more than 48 bits which would make bruteforce way more practical when considering an attack from a miner.
- We could tweak our keys or keys usage.
- We could use an OP_RETURN output committing to the spent txid. Albeit the concern of abusing the block chain it is the most straightforward solution, making it a good candidate at this stage of development. This is what this pull request implements.