### PR TITLE
Fixup typos in messages

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -282,12 +282,8 @@ Sent by a wallet to retrieve all signatures for a specific transaction.
 {
     "result": {
         "signatures": {
-            "pubkeyA": {
-                "signature": "Bitcoin ECDSA signature"
-            },
-            "pubkeyC": {
-                "signature": "Bitcoin ECDSA signature"
-            }
+            "pubkeyA": "Bitcoin ECDSA signature",
+            "pubkeyC": "Bitcoin ECDSA signature"
         }
     }
 }

--- a/messages.md
+++ b/messages.md
@@ -308,7 +308,7 @@ set of Unvault.
 {
     "method": "set_spend_tx",
     "params": {
-        "deposit_outpoint": ["txid:vout", "txid:vout"],
+        "deposit_outpoints": ["txid:vout", "txid:vout"],
         "spend_tx": "base64 of Bitcoin-serialized fully-signed spend transaction"
     }
 }


### PR DESCRIPTION
Noticed when implementing a dummy coordinator in Python: there are many inconsistencies between `revault_net` and the specs here. This correct the one where the specs were wrong.